### PR TITLE
Feature/renderable

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ before diving deeper into using other games engines (although I have done some b
 - Basic Sprite animations through Texture atlas/sprite sheets
 - Basic Tilemap support loading from json
 - Batch Rendering multiple sprites with one draw call (or currently one per about 1000 sprites)
+  on anything that implements `Renderable2D` trait
 - FrameBuffer for off screen rendering and full screen post-processing effects (currently implemented as RenderTarget in batch renderer)
 - Load fonts and render text through `rusttype` with gpu cache
 

--- a/examples/kitchen-sink/main.rs
+++ b/examples/kitchen-sink/main.rs
@@ -208,8 +208,8 @@ fn run() -> Result<(), failure::Error> {
     let start_pos = (300.0, 300.0);
     for i in 0..4 {
         let pos = (
-            start_pos.0 + 200.0 + (i as f32 * 40.0),//+ 40.0 + (i * 20) as f32 + 200.0,
-            start_pos.1 - 100.0 - (i as f32 * 40.0),//- 20.0 - (i * 10) as f32 - 100.0,
+            start_pos.0 + 200.0 + (i as f32 * 40.0),
+            start_pos.1 - 100.0 - (i as f32 * 40.0),
             0.0
         );
         let alpha = match i {
@@ -221,7 +221,7 @@ fn run() -> Result<(), failure::Error> {
             SpriteProps {
                 pos: pos,
                 dim: (240, 240),
-                color: (255, 255, 255, alpha),//(20, 30, 80, 0.5),
+                color: (255, 255, 255, alpha),
                 texture_slot: 4,
             },
         )?;
@@ -383,9 +383,7 @@ fn run() -> Result<(), failure::Error> {
         renderer.submit(&ninja_as_sprite);
         renderer.submit(&spritesheet_as_sprite);
 
-        for ts in tilemap.get_vertices() {
-            renderer.submit(&ts);
-        }
+        renderer.submit(&tilemap);
 
         renderer.end_batch();
         renderer.render(&camera);

--- a/src/renderer/renderable.rs
+++ b/src/renderer/renderable.rs
@@ -1,4 +1,31 @@
-trait Renderable2D {
-    fn get_texture_handle(&self) -> u32;
-    fn get_vertices(&self) -> Vec<SpriteVertex>;
+use crate::helpers::data;
+
+pub trait RenderVertex {
+    fn position(&self) -> data::f32_f32_f32 {
+        (0.0, 0.0, 0.0).into()
+    }
+    fn uv(&self) -> data::f32_f32 {
+        (0.0, 0.0).into()
+    }
+    fn color(&self) -> data::f32_f32_f32_f32 {
+        (0.0, 0.0, 0.0, 0.0).into()
+    }
+    fn texture_translate(&self) -> data::f32_f32_f32 {
+        (0.0, 0.0, 0.0).into()
+    }
+    fn texture_scale(&self) -> data::f32_f32_f32 {
+        (0.0, 0.0, 0.0).into()
+    }
+}
+
+pub trait Renderable2D {
+    fn texture(&self) -> u32 {
+        // default should be 0? or whatever determines
+        // no texture
+        0
+    }
+
+    fn vertices(&self) -> Vec<Box<dyn RenderVertex>> {
+        Vec::new()
+    }
 }

--- a/src/sprite/mod.rs
+++ b/src/sprite/mod.rs
@@ -2,6 +2,7 @@ use crate::helpers::{data};
 use crate::resources::*;
 use crate::textures::texture::{Texture};
 use crate::textures::transform::{TextureTransform};
+use crate::renderer::renderable::{Renderable2D, RenderVertex};
 
 #[derive(VertexAttribPointers)]
 #[derive(Copy, Clone, Debug, PartialEq)]
@@ -19,24 +20,24 @@ pub struct SpriteVertex {
     tex_scale: data::f32_f32_f32,
 }
 
-impl SpriteVertex {
-    pub fn get_pos(&self) -> data::f32_f32_f32 {
+impl RenderVertex for SpriteVertex {
+    fn position(&self) -> data::f32_f32_f32 {
         self.pos
     }
 
-    pub fn get_tex(&self) -> data::f32_f32 {
+    fn uv(&self) -> data::f32_f32 {
         self.tex
     }
 
-    pub fn get_color(&self) -> data::f32_f32_f32_f32 {
+    fn color(&self) -> data::f32_f32_f32_f32 {
         self.color
     }
 
-    pub fn get_texture_translate(&self) -> data::f32_f32_f32 {
+    fn texture_translate(&self) -> data::f32_f32_f32 {
         self.tex_translate
     }
 
-    pub fn get_texture_scale(&self) -> data::f32_f32_f32 {
+    fn texture_scale(&self) -> data::f32_f32_f32 {
         self.tex_scale
     }
 }
@@ -59,8 +60,7 @@ impl Default for SpriteProps {
         }
     }
 }
-//let pos = glm::vec3(x, y, 0.0);
-//let model = glm::translate(&glm::identity(), &pos);
+
 #[derive(PartialEq, Debug)]
 pub struct SpriteTransform {
     translation: glm::Mat4,
@@ -130,6 +130,21 @@ pub struct Sprite {
     texture_transform: TextureTransform,
     image_path: String,
     props: SpriteProps,
+}
+
+impl Renderable2D for Sprite {
+    fn texture(&self) -> u32 {
+        self.texture.texture_handle
+    }
+
+    fn vertices(&self) -> Vec<Box<RenderVertex>> {
+        let mut v = Vec::new();
+        for sv in &self.vertices {
+            v.push(Box::new(*sv) as Box<RenderVertex>);
+        }
+
+        v
+    }
 }
 
 impl Sprite {

--- a/src/tilemaps/mod.rs
+++ b/src/tilemaps/mod.rs
@@ -6,6 +6,7 @@ use std::path::Path;
 
 use crate::resources::*;
 use crate::textures::texture::*;
+use crate::renderer::renderable::{Renderable2D, RenderVertex};
 use crate::sprite::{Sprite, SpriteProps};
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -71,6 +72,24 @@ pub struct Tilemap {
     tileset: Tileset,
     // TODO: temporary here because easier to access, might need ot work with layers in some way?
     vertices: Vec<Sprite>,
+}
+
+impl Renderable2D for Tilemap {
+    fn texture(&self) -> u32 {
+        self.tileset.get_texture().texture_handle
+    }
+
+    fn vertices(&self) -> Vec<Box<RenderVertex>> {
+        let mut v = Vec::new();
+        for ts in &self.vertices {
+            let sv = ts.vertices();
+            for vs in sv {
+                v.push(vs);
+            }
+        }
+
+        v
+    }
 }
 
 impl Tilemap {


### PR DESCRIPTION
- Add a `Renderable2D` and `RenderVertex` trait
- Batch renderer submit now takes any anything that implements `Renderable2D` trait
- Tilemap now implements `Renderable2D` and can be submitted to the batch renderer altogether without 
  iterating each Tile Sprite in the map